### PR TITLE
client_secret shouldn't be required for grant_type `password`.

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -163,7 +163,9 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     [mutableParameters setObject:self.clientID forKey:@"client_id"];
-    [mutableParameters setObject:self.secret forKey:@"client_secret"];
+    if (self.secret.length > 0) {
+        [mutableParameters setObject:self.secret forKey:@"client_secret"];
+    }
     parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
     [self clearAuthorizationHeader];


### PR DESCRIPTION
While using grant_type `password`, transmitting a `client_secret` is not required or/and shouldn't be used under the assumption that most of the use cases for password grants will be mobile or desktop apps, where the secret cannot be protected.
