### PR TITLE
Fixed crash when `expires_in` is null

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -188,9 +188,15 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
         refreshToken = refreshToken ? refreshToken : [parameters valueForKey:@"refresh_token"];
 
         AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
-        [credential setRefreshToken:refreshToken expiration:[NSDate dateWithTimeIntervalSinceNow:[[responseObject valueForKey:@"expires_in"] integerValue]]];
+ 
+	NSDate *expireDate = nil;
+	if ([responseObject valueForKey:@"expires_in"] != nil && [responseObject valueForKey:@"expires_in"] != [NSNull null]) {
+		expireDate = [NSDate dateWithTimeIntervalSinceNow:[[responseObject valueForKey:@"expires_in"] integerValue]];
+	}
 
-        [self setAuthorizationHeaderWithCredential:credential];
+	[credential setRefreshToken:refreshToken expiration:expireDate];
+
+       	[self setAuthorizationHeaderWithCredential:credential];
 
         if (success) {
             success(credential);


### PR DESCRIPTION
I am not sure if `expires_in` can be null. But I am using an API that has a token that never expires, this fixes the issue I was having with it.
