### PR TITLE
bug fix : changing expires_in to doubleValue

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -188,7 +188,10 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
         refreshToken = refreshToken ? refreshToken : [parameters valueForKey:@"refresh_token"];
 
         AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
-        [credential setRefreshToken:refreshToken expiration:[NSDate dateWithTimeIntervalSinceNow:[[responseObject valueForKey:@"expires_in"] integerValue]]];
+        //expires_in date should be considered as double
+        //1-It's the tru type of NSTimeInterval
+        //2-For permamnent exiration dates = more than 20 years
+        [credential setRefreshToken:refreshToken expiration:[NSDate dateWithTimeIntervalSinceNow:[[responseObject valueForKey:@"expires_in"] doubleValue]]];
 
         [self setAuthorizationHeaderWithCredential:credential];
 


### PR DESCRIPTION
expires_in value is considered to be an integer but it's really an NSTimeInterval aka double
