### PR TITLE
always use x-www-form-url to encode the parameters of authentication-requests

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -169,9 +169,14 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
     parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
     [self clearAuthorizationHeader];
+    
+    AFHTTPClientParameterEncoding originalParameterEncoding = self.parameterEncoding;
+    self.parameterEncoding = AFFormURLParameterEncoding;
 
     NSMutableURLRequest *mutableRequest = [self requestWithMethod:@"POST" path:path parameters:parameters];
     [mutableRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    
+    self.parameterEncoding = originalParameterEncoding;
 
     AFHTTPRequestOperation *requestOperation = [self HTTPRequestOperationWithRequest:mutableRequest success:^(AFHTTPRequestOperation *operation, id responseObject) {
         if ([responseObject valueForKey:@"error"]) {


### PR DESCRIPTION
This saves the current `self.parameterEncoding` and sets it to `AFFormURLParameterEncoding` to create the `NSMutableURLRequest` used to authenticate and restores the original setting right afterwards.

I am aware that creating additional other requests in concurrent threads could lead to a wrong parameter-encoding in those.
However, to fix this issue, greater architectural changes would be needed (like introducing a new `requestWithMethod:path:parameters:encoding`, for example).
Also, I rate the potential risk of this happening as low as people who are creating requests on multiple threads are either doing something wrong (and thus will run into other problems) or know exactly what they are doing (and thus should be able to handle this issue according to their situation).
