### PR TITLE
use the stored credential's refresh-token

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -152,7 +152,7 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kAFOAuthRefreshGrantType forKey:@"grant_type"];
-    [mutableParameters setValue:refreshToken forKey:@"refresh_token"];
+    [mutableParameters setValue:self.credential.refreshToken forKey:@"refresh_token"];
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
     [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];


### PR DESCRIPTION
WARNING: _This pull-request depends on #25 and will leave you with broken code, if you don't apply both!_

Use the refresh-token of the stored credential. This prepares API-simplifications and automatic refreshing.
