### PR TITLE
renamed the main authentication calls and stripped unused parameters

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.h
+++ b/AFOAuth2Client/AFOAuth2Client.h
@@ -75,45 +75,39 @@
 /**
  
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                                  code:(NSString *)code
-                           redirectURI:(NSString *)uri
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure;
+- (void)obtainAccessTokenUsingAuthorizationCodeGrantWithCode:(NSString *)code
+                                                 redirectURI:(NSString *)uri
+                                                     success:(void (^)(AFOAuthCredential *credential))success
+                                                     failure:(void (^)(NSError *error))failure;
 
 /**
  
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                              username:(NSString *)username
-                              password:(NSString *)password
-                                 scope:(NSString *)scope
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure;
+- (void)obtainAccessTokenUsingResourceOwnerPasswordCredentialsGrantWithUsername:(NSString *)username
+                                                                       password:(NSString *)password
+                                                                          scope:(NSString *)scope
+                                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                                        failure:(void (^)(NSError *error))failure;
 
 /**
  
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                                 scope:(NSString *)scope
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure;
+- (void)obtainAccessTokenUsingClientCredentialsGrantWithScope:(NSString *)scope
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure;
 
 /**
  
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                          refreshToken:(NSString *)refreshToken
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure;
+- (void)refreshAccessTokenWithSuccess:(void (^)(AFOAuthCredential *credential))success
+                              failure:(void (^)(NSError *error))failure;
 
 /**
  
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                            parameters:(NSDictionary *)parameters
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure;
+- (void)requestTokenEndpointWithParameters:(NSDictionary *)parameters
+                                   success:(void (^)(AFOAuthCredential *credential))success
+                                   failure:(void (^)(NSError *error))failure;
 
 @end
 

--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -100,11 +100,10 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
 
 #pragma mark -
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                                  code:(NSString *)code
-                           redirectURI:(NSString *)uri
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure
+- (void)obtainAccessTokenUsingAuthorizationCodeGrantWithCode:(NSString *)code
+                                                 redirectURI:(NSString *)uri
+                                                     success:(void (^)(AFOAuthCredential *credential))success
+                                                     failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kAFOAuthCodeGrantType forKey:@"grant_type"];
@@ -112,15 +111,14 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
     [mutableParameters setValue:uri forKey:@"redirect_uri"];
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
-    [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
+    [self requestTokenEndpointWithParameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                              username:(NSString *)username
-                              password:(NSString *)password
-                                 scope:(NSString *)scope
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure
+- (void)obtainAccessTokenUsingResourceOwnerPasswordCredentialsGrantWithUsername:(NSString *)username
+                                                                       password:(NSString *)password
+                                                                          scope:(NSString *)scope
+                                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                                        failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kAFOAuthPasswordCredentialsGrantType forKey:@"grant_type"];
@@ -129,39 +127,35 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
     [mutableParameters setValue:scope forKey:@"scope"];
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
-    [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
+    [self requestTokenEndpointWithParameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                                 scope:(NSString *)scope
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure
+- (void)obtainAccessTokenUsingClientCredentialsGrantWithScope:(NSString *)scope
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kAFOAuthClientCredentialsGrantType forKey:@"grant_type"];
     [mutableParameters setValue:scope forKey:@"scope"];
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
-    [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
+    [self requestTokenEndpointWithParameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                          refreshToken:(NSString *)refreshToken
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure
+- (void)refreshAccessTokenWithSuccess:(void (^)(AFOAuthCredential *credential))success
+                              failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kAFOAuthRefreshGrantType forKey:@"grant_type"];
     [mutableParameters setValue:refreshToken forKey:@"refresh_token"];
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
-    [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
+    [self requestTokenEndpointWithParameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path
-                            parameters:(NSDictionary *)parameters
-                               success:(void (^)(AFOAuthCredential *credential))success
-                               failure:(void (^)(NSError *error))failure
+- (void)requestTokenEndpointWithParameters:(NSDictionary *)parameters
+                                   success:(void (^)(AFOAuthCredential *))success
+                                   failure:(void (^)(NSError *))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     [mutableParameters setObject:self.clientID forKey:@"client_id"];


### PR DESCRIPTION
WARNING: _This pull-request depends on #26 and #24 and will leave you with broken code, if you don't apply all of them!_

Using the changes introduced in previous pull-requests (using the stored refresh-token and a fixed token-endpoint), this cuts away the `path`-parameter from all authentication-methods and the `refreshToken`-parameter from the refreshing-method.

Additionally, all methods have been renamed to make the change more visible to developers who want to introduce this and to be closer to the terminology of the specification, which should make using the client easier for new developers.
