### PR TITLE
Automatically refresh access-tokens

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -227,6 +227,7 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
             if (failure) {
                 failure(request, error);
             }
+            return;
         }
         
         // Check for expired credential. TODO: Check server-response instead of our cached version


### PR DESCRIPTION
Fixes issue #12.

WARNING: _This pull-request depends on #27 and will leave you with broken code if you don't apply both._

By injecting an extended `failure`-block, the client checks for expiration of the cached token and tries refreshing it.
If a new token can be obtained, the original request is repeated with the new authorization-header.
If no new token can be obtained or something else goes wrong, the original `failure`-block is called, handing down either the original error or the error that came up when refreshing.
