### PR TITLE
Allow `setAuthorizationHeaderWithUsername` to work when called before getting OAuth credentials.

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -168,8 +168,6 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
     [mutableParameters setValue:self.secret forKey:@"client_secret"];
     parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
-    [self clearAuthorizationHeader];
-
     NSMutableURLRequest *mutableRequest = [self requestWithMethod:@"POST" path:path parameters:parameters];
     [mutableRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
 
@@ -199,6 +197,7 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
 
         [credential setRefreshToken:refreshToken expiration:expireDate];
 
+        [self clearAuthorizationHeader];
         [self setAuthorizationHeaderWithCredential:credential];
 
         if (success) {


### PR DESCRIPTION
This allows authorization to be set, and used, outside the call to
`authenticateUsingOAuthWithPath...`
