### PR TITLE
Allow to (optionnaly) set Keychain Service Name

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.h
+++ b/AFOAuth2Client/AFOAuth2Client.h
@@ -188,12 +188,33 @@
 /**
 
  */
++ (BOOL)storeCredential:(AFOAuthCredential *)credential
+         withIdentifier:(NSString *)identifier
+         andServiceName:(NSString *)serviceName;
+
+
+/**
+
+ */
 + (BOOL)deleteCredentialWithIdentifier:(NSString *)identifier;
 
 /**
 
  */
++ (BOOL)deleteCredentialWithIdentifier:(NSString *)identifier
+                        andServiceName:(NSString *)serviceName;
+
+
+/**
+
+ */
 + (AFOAuthCredential *)retrieveCredentialWithIdentifier:(NSString *)identifier;
+
+/**
+
+ */
++ (AFOAuthCredential *)retrieveCredentialWithIdentifier:(NSString *)identifier
+                                         andServiceName:(NSString *)serviceName;
 #endif
 
 @end


### PR DESCRIPTION
When using AFOAuth2Client and storing credentials on Mac OS X, a popup is presented to the user with the following text:
"NameOfTheApp wants to use your confidential information stored in "AFOAuthCredentialService" in your keychain. Do you want to allow access to this item?

Always Allow, Deny, Allow"

This is not user friendly and would be better for the user to present the Name of the App (most of them don't know how awesome is AFNetworking).

Also I needed to access some data in the keychain stored by a previous version of my app with a different service name.

So I expose 3 new methods, that allows you to specify the identifier AND the service name.
I kept the original AFKeychainQueryDictionaryWithIdentifier method in case people have specific usage of this method, but maybe we can remove it as it is totally internal.

