### PR TITLE
Allow an expiration date without using a refresh token

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -260,12 +260,12 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
 - (void)setRefreshToken:(NSString *)refreshToken
              expiration:(NSDate *)expiration
 {
-    if (!refreshToken || !expiration) {
-        return;
+    if (refreshToken) {
+        self.refreshToken = refreshToken;
     }
-
-    self.refreshToken = refreshToken;
-    self.expiration = expiration;
+    if (expiration) {
+        self.expiration = expiration;
+    }
 }
 
 - (BOOL)isExpired {


### PR DESCRIPTION
In some cases you may want to use an expiration date for access tokens,
but no refresh tokens. This small fix will allow that.

I made this change for a small project with an Client Credentials Flow without refresh tokens. I think it should also fix #34.
