### PR TITLE
Check for access_token & token_type, default setted to Bearer

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -187,9 +187,22 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
         if (refreshToken == nil || [refreshToken isEqual:[NSNull null]]) {
             refreshToken = [parameters valueForKey:@"refresh_token"];
         }
-
-        AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
-
+    
+        // Ensure response contains access_token
+        if(![responseObject valueForKey:@"access_token"]){
+            NSDictionary *errorDictionary = @{ NSLocalizedDescriptionKey : @"Access token not setted"};
+            failure([NSError errorWithDomain:@"AFOAuth2Client" code:1 userInfo:errorDictionary]);
+        }
+        
+        // Check for token_type
+        NSString *tokenType = [responseObject valueForKey:@"token_type"];
+        if(!tokenType){
+            NSLog(@"Waring: Server response does not contain token_type, using Bearer.");
+            tokenType = @"Bearer";
+        }
+        
+        AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:tokenType];
+        
         NSDate *expireDate = nil;
         id expiresIn = [responseObject valueForKey:@"expires_in"];
         if (expiresIn != nil && ![expiresIn isEqual:[NSNull null]]) {


### PR DESCRIPTION
Hi!
I was making a project with django rest api and it doesn't set the token_type assuming is a Bearer type. Maybe forgetting to set token_type is not standard compilance, but it helps to have a notice on AFOauth.

Thanks :-) 
