### PR TITLE
import frameworks in pch file

### DIFF
--- a/AFOAuth2Client.podspec
+++ b/AFOAuth2Client.podspec
@@ -17,6 +17,13 @@ Pod::Spec.new do |s|
   s.prefix_header_contents = <<-EOS
 #ifdef __OBJC__
   #import <Security/Security.h>
+  #if __IPHONE_OS_VERSION_MIN_REQUIRED
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <MobileCoreServices/MobileCoreServices.h>
+  #else
+    #import <SystemConfiguration/SystemConfiguration.h>
+    #import <CoreServices/CoreServices.h>
+  #endif
 #endif /* __OBJC__*/
 EOS
 end


### PR DESCRIPTION
Suppresses warnings when used as a dependency in other projects.
