### PR TITLE
don't set the refresh token if neither refresh token nor expire date is provided

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -194,7 +194,9 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
             expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
         }
 
-        [credential setRefreshToken:refreshToken expiration:expireDate];
+        if (refreshToken || expireDate) {
+            [credential setRefreshToken:refreshToken expiration:expireDate];
+        }
 
         [self setAuthorizationHeaderWithCredential:credential];
 


### PR DESCRIPTION
Fixes issue #70 - makes `expires_in` optional.
