### PR TITLE
FIX: Does not handle responses with missing 'expires_in'.

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -194,7 +194,7 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
             expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
         }
 
-        [credential setRefreshToken:refreshToken expiration:expireDate];
+        if (expireDate) [credential setRefreshToken:refreshToken expiration:expireDate];
 
         [self setAuthorizationHeaderWithCredential:credential];
 


### PR DESCRIPTION
[SalesForce API](https://www.salesforce.com/us/developer/docs/api_rest/) does not return `refresh_token` and `expires_in` when username-password authentication is performed causing the lib to crash.

It also fixes #70.
