### PR TITLE
Remove requirement so expiration can be set with or w/o a refreshToken

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -216,6 +216,22 @@
 ///----------------------------
 
 /**
+ Set the credential refresh token, without a specific expiration
+
+ @param refreshToken The OAuth refresh token.
+ */
+- (void)setRefreshToken:(NSString *)refreshToken;
+
+
+/**
+ Set the expiration on the access token. If no expiration is given by the OAuth2 provider,
+ you may pass in [NSDate distantFuture]
+
+ @param expiration The expiration of the access token. This must not be `nil`.
+ */
+- (void)setExpiration:(NSDate *)expiration;
+
+/**
  Set the credential refresh token, with a specified expiration.
 
  @param refreshToken The OAuth refresh token.

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -227,7 +227,7 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
             expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
         }
 
-        if (refreshToken && expireDate) {
+        if (expireDate) {
             [credential setRefreshToken:refreshToken expiration:expireDate];
         }
 

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -221,6 +221,12 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 
         AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
 
+
+        if (refreshToken) { // refreshToken is optional in the OAuth2 spec
+            [credential setRefreshToken:refreshToken];
+        }
+
+        // Expiration is optional, but recommended in the OAuth2 spec. It not provide, assume distantFuture === never expires
         NSDate *expireDate = [NSDate distantFuture];
         id expiresIn = [responseObject valueForKey:@"expires_in"];
         if (expiresIn && ![expiresIn isEqual:[NSNull null]]) {
@@ -228,7 +234,7 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
         }
 
         if (expireDate) {
-            [credential setRefreshToken:refreshToken expiration:expireDate];
+            [credential setExpiration:expireDate];
         }
 
         if (success) {
@@ -282,8 +288,19 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 }
 
 - (void)setRefreshToken:(NSString *)refreshToken
+{
+    _refreshToken = refreshToken;
+}
+
+- (void)setExpiration:(NSDate *)expiration
+{
+    _expiration = expiration;
+}
+
+- (void)setRefreshToken:(NSString *)refreshToken
              expiration:(NSDate *)expiration
 {
+    NSParameterAssert(refreshToken);
     NSParameterAssert(expiration);
 
     self.refreshToken = refreshToken;


### PR DESCRIPTION
This should address concerns in Issues #70, #71, and #82:
* `expires_in` is officially optional, but recommended
* `refresh_token` is optional
* APIs may return `expires_in` without the `refresh_token`
