### PR TITLE
Client secret should not be mandatory

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -194,7 +194,9 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     mutableParameters[@"client_id"] = self.clientID;
-    mutableParameters[@"client_secret"] = self.secret;
+    if (self.secret && secret.length > 0) {
+        mutableParameters[@"client_secret"] = self.secret;
+    }
     parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
     [self POST:URLString parameters:parameters success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {


### PR DESCRIPTION
This issue [was already reported some time ago] (https://github.com/AFNetworking/AFOAuth2Manager/pull/9), but those changes are disappeared after moving from AFOAuth2Client to AFOAuth2Manager.

I think it would be great to add it again.