### PR TITLE
[Issue 85] by default, use http basic auth to include client credentials in requests

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -67,7 +67,7 @@
                            secret:(NSString *)secret;
 
 /**
- Initializes an `AFOAuth2Manager` object with the specified base URL, client identifier, and secret.
+ Initializes an `AFOAuth2Manager` object with the specified base URL, client identifier, and secret. The communication to to the server will use HTTP basic auth by default (use `-(id)initWithBaseURL:clientID:secret:withBasicAuth:` to change this).
 
  @param url The base URL for the HTTP client. This argument must not be `nil`.
  @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
@@ -78,6 +78,21 @@
 - (id)initWithBaseURL:(NSURL *)url
              clientID:(NSString *)clientID
                secret:(NSString *)secret;
+
+/**
+ Initializes an `AFOAuth2Manager` object with the specified base URL, client identifier, and secret.
+ 
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+ @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
+ @param secret The client secret.
+ @param whether to use HTTP basic auth when communicating with the server. It is recommended to use basic auth.
+ 
+ @return The newly-initialized OAuth 2 client
+ */
+- (id)initWithBaseURL:(NSURL *)url
+             clientID:(NSString *)clientID
+               secret:(NSString *)secret
+        withBasicAuth:(BOOL)basicAuth;
 
 ///---------------------
 /// @name Authenticating

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -85,6 +85,7 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 @property (readwrite, nonatomic, copy) NSString *serviceProviderIdentifier;
 @property (readwrite, nonatomic, copy) NSString *clientID;
 @property (readwrite, nonatomic, copy) NSString *secret;
+@property (readonly, nonatomic)  BOOL basicAuth;
 @end
 
 @implementation AFOAuth2Manager
@@ -100,19 +101,31 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
              clientID:(NSString *)clientID
                secret:(NSString *)secret
 {
-    NSParameterAssert(clientID);
+    return [self initWithBaseURL:url clientID:clientID secret:secret withBasicAuth:YES];
+}
 
+- (id)initWithBaseURL:(NSURL *)url
+             clientID:(NSString *)clientID
+               secret:(NSString *)secret
+        withBasicAuth:(BOOL)basicAuth
+{
+    NSParameterAssert(clientID);
+    
     self = [super initWithBaseURL:url];
     if (!self) {
         return nil;
     }
-
+    
     self.serviceProviderIdentifier = [self.baseURL host];
     self.clientID = clientID;
     self.secret = secret;
-
+    _basicAuth = basicAuth;
+    if (self.basicAuth) {
+        [self.requestSerializer setAuthorizationHeaderFieldWithUsername:clientID password:secret];
+    }
+    
     [self.requestSerializer setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-
+    
     return self;
 }
 

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -206,8 +206,11 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                     failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
-    mutableParameters[@"client_id"] = self.clientID;
-    mutableParameters[@"client_secret"] = self.secret;
+    if (!self.basicAuth)
+    {
+        mutableParameters[@"client_id"] = self.clientID;
+        mutableParameters[@"client_secret"] = self.secret;
+    }
     parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
     [self POST:URLString parameters:parameters success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {


### PR DESCRIPTION
Pretty  self explanatory. as per #85 , we should no be putting client credentials in the request body. This is a rough port of a similar PR for AFOAuth2Client v1