### PR TITLE
Added return of current AFHTTPRequestOperation

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -93,7 +93,7 @@
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                    username:(NSString *)username
                                    password:(NSString *)password
                                       scope:(NSString *)scope
@@ -108,7 +108,7 @@
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                       scope:(NSString *)scope
                                     success:(void (^)(AFOAuthCredential *credential))success
                                     failure:(void (^)(NSError *error))failure;
@@ -121,7 +121,7 @@
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                refreshToken:(NSString *)refreshToken
                                     success:(void (^)(AFOAuthCredential *credential))success
                                     failure:(void (^)(NSError *error))failure;
@@ -135,7 +135,7 @@
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                        code:(NSString *)code
                                 redirectURI:(NSString *)uri
                                     success:(void (^)(AFOAuthCredential *credential))success
@@ -149,7 +149,7 @@
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                  parameters:(NSDictionary *)parameters
                                     success:(void (^)(AFOAuthCredential *credential))success
                                     failure:(void (^)(NSError *error))failure;

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -118,7 +118,7 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 
 #pragma mark -
 
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                    username:(NSString *)username
                                    password:(NSString *)password
                                       scope:(NSString *)scope
@@ -136,10 +136,10 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                  @"scope": scope
                                 };
 
-    [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                       scope:(NSString *)scope
                                     success:(void (^)(AFOAuthCredential *credential))success
                                     failure:(void (^)(NSError *error))failure
@@ -151,10 +151,10 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                  @"scope": scope
                                 };
 
-    [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                refreshToken:(NSString *)refreshToken
                                     success:(void (^)(AFOAuthCredential *credential))success
                                     failure:(void (^)(NSError *error))failure
@@ -166,10 +166,10 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                  @"refresh_token": refreshToken
                                 };
 
-    [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                        code:(NSString *)code
                                 redirectURI:(NSString *)uri
                                     success:(void (^)(AFOAuthCredential *credential))success
@@ -184,10 +184,10 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                  @"redirect_uri": uri
                                 };
 
-    [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithURLString:(NSString *)URLString
+- (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                  parameters:(NSDictionary *)parameters
                                     success:(void (^)(AFOAuthCredential *credential))success
                                     failure:(void (^)(NSError *error))failure
@@ -197,7 +197,7 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     mutableParameters[@"client_secret"] = self.secret;
     parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
 
-    [self POST:URLString parameters:parameters success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
+    AFHTTPRequestOperation *requestOperation = [self POST:URLString parameters:parameters success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
         if (!responseObject) {
             if (failure) {
                 failure(nil);
@@ -239,6 +239,8 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
             failure(error);
         }
     }];
+    
+    return requestOperation;
 }
 
 @end


### PR DESCRIPTION
I changed the definition of all `authenticateUsingOAuthWithURLString`-Methods to make sure they return their current `AFHTTPRequestOperation`.

In my opinion this can be useful when using NSOperation dependencies.

In my current project every HTTP call is made like this:

1) Check if there is a required authorization
2) If there is one check their current state
3) If new authentication is needed or token has to be refreshed before the next call is made then create a new `AFHTTPRequestOperation` for OAuth authentication
4) Create the primary request with all its parameters, etc. Set the request from 3) as the dependent `NSOperation`
