### PR TITLE
allowed to retrieve the expiration date of AFOAuthCredential

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -190,6 +190,11 @@
 @property (readonly, nonatomic, copy) NSString *refreshToken;
 
 /**
+ The OAuth expiration date.
+ */
+@property (readonly, nonatomic, copy) NSDate *expiration;
+
+/**
  Whether the OAuth credentials are expired.
  */
 @property (readonly, nonatomic, assign, getter = isExpired) BOOL expired;


### PR DESCRIPTION
Why it is not allowed by default?
