### PR TITLE
Fixed a warning

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -344,9 +344,12 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 {
     id securityAccessibility = nil;
 #if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 43000) || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
     if (&kSecAttrAccessibleWhenUnlocked != NULL) {
         securityAccessibility = (__bridge id)kSecAttrAccessibleWhenUnlocked;
     }
+#pragma clang diagnostic pop
 #endif
 
     return [[self class] storeCredential:credential withIdentifier:identifier withAccessibility:securityAccessibility];


### PR DESCRIPTION
````
AFOAuth2Manager.m:347:10: Comparison of address of 'kSecAttrAccessibleWhenUnlocked' not equal to a null pointer is always true
````