### PR TITLE
Remove NSLog statements

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -379,10 +379,6 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
         status = SecItemAdd((__bridge CFDictionaryRef)queryDictionary, NULL);
     }
 
-    if (status != errSecSuccess) {
-        NSLog(@"Unable to %@ credential with identifier \"%@\" (Error %li)", exists ? @"update" : @"add", identifier, (long int)status);
-    }
-
     return (status == errSecSuccess);
 }
 
@@ -390,10 +386,6 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     NSMutableDictionary *queryDictionary = [AFKeychainQueryDictionaryWithIdentifier(identifier) mutableCopy];
 
     OSStatus status = SecItemDelete((__bridge CFDictionaryRef)queryDictionary);
-
-    if (status != errSecSuccess) {
-        NSLog(@"Unable to delete credential with identifier \"%@\" (Error %li)", identifier, (long int)status);
-    }
 
     return (status == errSecSuccess);
 }
@@ -407,7 +399,6 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)queryDictionary, (CFTypeRef *)&result);
 
     if (status != errSecSuccess) {
-        NSLog(@"Unable to fetch credential with identifier \"%@\" (Error %li)", identifier, (long int)status);
         return nil;
     }
 


### PR DESCRIPTION
This prevents from leaking the identifier used to store a credential, as described in #97.