### PR TITLE
Fix imports to work as framework

### DIFF
--- a/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
+++ b/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFURLRequestSerialization.h"
+#import <AFNetworking/AFURLRequestSerialization.h>
 
 @class AFOAuthCredential;
 

--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -22,7 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "AFHTTPRequestOperationManager.h"
+#import <AFNetworking/AFHTTPRequestOperationManager.h>
 
 @class AFOAuthCredential;
 


### PR DESCRIPTION
This updates the `AFNetworking` dependencies imports to be system imports instead of local to fix the problem with `cocoapods`  `use_framework!`