### PR TITLE
NSURLSession based Manager + AFNetworking 3.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Xcode
+.DS_Store
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+.idea/

--- a/AFOAuth2Manager.podspec
+++ b/AFOAuth2Manager.podspec
@@ -1,20 +1,40 @@
 Pod::Spec.new do |s|
   s.name     = 'AFOAuth2Manager'
-  s.version  = '2.2.0'
+  s.version  = '2.3.0'
   s.license  = 'MIT'
   s.summary  = 'AFNetworking Extension for OAuth 2 Authentication.'
   s.homepage = 'https://github.com/AFNetworking/AFOAuth2Manager'
   s.social_media_url = "https://twitter.com/AFNetworking"
   s.author   = { 'Mattt Thompson' => 'm@mattt.me' }
-  s.source   = { :git => 'https://github.com/AFNetworking/AFOAuth2Manager.git',
-                 :tag => s.version }
-  s.source_files = 'AFOAuth2Manager'
+  s.source   = { :git => 'https://github.com/AFNetworking/AFOAuth2Manager.git', :tag => s.version }
   s.requires_arc = true
 
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
 
-  s.dependency 'AFNetworking/NSURLConnection', '~>2.2'
-
   s.ios.frameworks = 'Security'
+
+  s.subspec 'Core' do |ss|
+    ss.dependency 'AFNetworking/Serialization', '~>2.2'
+
+    ss.source_files = 'AFOAuth2Manager/AFOAuth2Constants.{h,m}', 'AFOAuth2Manager/AFOAuthCredential.{h,m}', 'AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.{h,m}'
+  end
+
+  s.subspec 'NSURLConnection' do |ss|
+    ss.dependency 'AFOAuth2Manager/Core'
+    ss.dependency 'AFNetworking/NSURLConnection', '~>2.2'
+
+    ss.source_files = 'AFOAuth2Manager/AFOAuth2Manager.{h,m}'
+  end
+
+  s.subspec 'NSURLSession' do |ss|
+    ss.ios.deployment_target = '7.0'
+    ss.osx.deployment_target = '10.9'
+
+    ss.dependency 'AFOAuth2Manager/Core'
+    ss.dependency 'AFNetworking/NSURLSession', '~>2.2'
+
+    ss.source_files = 'AFNetworking/AFOAuth2SessionManager.{h,m}'
+  end
+
 end

--- a/AFOAuth2Manager.podspec
+++ b/AFOAuth2Manager.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.ios.frameworks = 'Security'
 
   s.subspec 'Core' do |ss|
-    ss.dependency 'AFNetworking/Serialization', '~>2.2'
+    ss.dependency 'AFNetworking/Serialization', '>=2.2'
 
     ss.source_files = 'AFOAuth2Manager/AFOAuth2Constants.{h,m}', 'AFOAuth2Manager/AFOAuthCredential.{h,m}', 'AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.{h,m}'
   end
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     ss.osx.deployment_target = '10.9'
 
     ss.dependency 'AFOAuth2Manager/Core'
-    ss.dependency 'AFNetworking/NSURLSession', '~>2.2'
+    ss.dependency 'AFNetworking/NSURLSession', '>=2.2'
 
     ss.source_files = 'AFOAuth2Manager/AFOAuth2SessionManager.{h,m}'
   end

--- a/AFOAuth2Manager.podspec
+++ b/AFOAuth2Manager.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ss.dependency 'AFOAuth2Manager/Core'
     ss.dependency 'AFNetworking/NSURLSession', '~>2.2'
 
-    ss.source_files = 'AFNetworking/AFOAuth2SessionManager.{h,m}'
+    ss.source_files = 'AFOAuth2Manager/AFOAuth2SessionManager.{h,m}'
   end
 
 end

--- a/AFOAuth2Manager.xcworkspace/contents.xcworkspacedata
+++ b/AFOAuth2Manager.xcworkspace/contents.xcworkspacedata
@@ -16,5 +16,11 @@
       <FileRef
          location = "group:AFOAuth2Manager.m">
       </FileRef>
+      <FileRef
+         location = "group:AFOAuthCredential.h">
+      </FileRef>
+      <FileRef
+         location = "group:AFOAuthCredential.m">
+      </FileRef>
    </Group>
 </Workspace>

--- a/AFOAuth2Manager.xcworkspace/contents.xcworkspacedata
+++ b/AFOAuth2Manager.xcworkspace/contents.xcworkspacedata
@@ -23,6 +23,12 @@
          location = "group:AFOAuth2Manager.m">
       </FileRef>
       <FileRef
+         location = "group:AFOAuth2SessionManager.h">
+      </FileRef>
+      <FileRef
+         location = "group:AFOAuth2SessionManager.m">
+      </FileRef>
+      <FileRef
          location = "group:AFOAuthCredential.h">
       </FileRef>
       <FileRef

--- a/AFOAuth2Manager.xcworkspace/contents.xcworkspacedata
+++ b/AFOAuth2Manager.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,12 @@
          location = "group:AFHTTPRequestSerializer+OAuth2.m">
       </FileRef>
       <FileRef
+         location = "group:AFOAuth2Constants.h">
+      </FileRef>
+      <FileRef
+         location = "group:AFOAuth2Constants.m">
+      </FileRef>
+      <FileRef
          location = "group:AFOAuth2Manager.h">
       </FileRef>
       <FileRef

--- a/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
+++ b/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFURLRequestSerialization.h"
+#import <AFNetworking/AFURLRequestSerialization.h>
 
 @class AFOAuthCredential;
 

--- a/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
+++ b/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
@@ -1,6 +1,6 @@
 // AFHTTPRequestSerializer+OAuth2.h
 //
-// Copyright (c) 2012-2014 AFNetworking (http://afnetworking.com)
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.m
+++ b/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.m
@@ -1,6 +1,6 @@
 // AFHTTPRequestSerializer+OAuth2.m
 //
-// Copyright (c) 2012-2014 AFNetworking (http://afnetworking.com)
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 #import "AFHTTPRequestSerializer+OAuth2.h"
-#import "AFOAuth2Manager.h"
+#import "AFOAuthCredential.h"
 
 @implementation AFHTTPRequestSerializer (OAuth2)
 

--- a/AFOAuth2Manager/AFOAuth2Constants.h
+++ b/AFOAuth2Manager/AFOAuth2Constants.h
@@ -1,0 +1,54 @@
+// AFOAuth2Constants.h
+//
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## Error Domains
+
+ The following error domain is predefined.
+
+ - `NSString * const AFOAuth2ErrorDomain`
+
+ ## OAuth Grant Types
+
+ OAuth 2.0 provides several grant types, covering several different use cases. The following grant type string constants are provided:
+
+ `kAFOAuthCodeGrantType`: "authorization_code"
+ `kAFOAuthClientCredentialsGrantType`: "client_credentials"
+ `kAFOAuthPasswordCredentialsGrantType`: "password"
+ `kAFOAuthRefreshGrantType`: "refresh_token"
+ */
+extern NSString * const AFOAuth2ErrorDomain;
+
+extern NSString * const kAFOAuthCodeGrantType;
+extern NSString * const kAFOAuthClientCredentialsGrantType;
+extern NSString * const kAFOAuthPasswordCredentialsGrantType;
+extern NSString * const kAFOAuthRefreshGrantType;
+
+
+// See: http://tools.ietf.org/html/rfc6749#section-5.2
+NSError * AFErrorFromRFC6749Section5_2Error(id object);

--- a/AFOAuth2Manager/AFOAuth2Constants.m
+++ b/AFOAuth2Manager/AFOAuth2Constants.m
@@ -1,0 +1,65 @@
+// AFOAuth2Constants.m
+//
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFOAuth2Constants.h"
+
+NSString * const AFOAuth2ErrorDomain = @"com.alamofire.networking.oauth2.error";
+
+NSString * const kAFOAuthCodeGrantType = @"authorization_code";
+NSString * const kAFOAuthClientCredentialsGrantType = @"client_credentials";
+NSString * const kAFOAuthPasswordCredentialsGrantType = @"password";
+NSString * const kAFOAuthRefreshGrantType = @"refresh_token";
+
+NSError * AFErrorFromRFC6749Section5_2Error(id object) {
+    if (![object valueForKey:@"error"] || [[object valueForKey:@"error"] isEqual:[NSNull null]]) {
+        return nil;
+    }
+
+    NSMutableDictionary *mutableUserInfo = [NSMutableDictionary dictionary];
+
+    NSString *description = nil;
+    if ([object valueForKey:@"error_description"]) {
+        description = [object valueForKey:@"error_description"];
+    } else {
+        if ([[object valueForKey:@"error"] isEqualToString:@"invalid_request"]) {
+            description = NSLocalizedStringFromTable(@"The request is missing a required parameter, includes an unsupported parameter value (other than grant type), repeats a parameter, includes multiple credentials, utilizes more than one mechanism for authenticating the client, or is otherwise malformed.", @"AFOAuth2Manager", @"invalid_request");
+        } else if ([[object valueForKey:@"error"] isEqualToString:@"invalid_client"]) {
+            description = NSLocalizedStringFromTable(@"Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method).  The authorization server MAY return an HTTP 401 (Unauthorized) status code to indicate which HTTP authentication schemes are supported.  If the client attempted to authenticate via the \"Authorization\" request header field, the authorization server MUST respond with an HTTP 401 (Unauthorized) status code and include the \"WWW-Authenticate\" response header field matching the authentication scheme used by the client.", @"AFOAuth2Manager", @"invalid_request");
+        } else if ([[object valueForKey:@"error"] isEqualToString:@"invalid_grant"]) {
+            description = NSLocalizedStringFromTable(@"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.", @"AFOAuth2Manager", @"invalid_request");
+        } else if ([[object valueForKey:@"error"] isEqualToString:@"unauthorized_client"]) {
+            description = NSLocalizedStringFromTable(@"The authenticated client is not authorized to use this authorization grant type.", @"AFOAuth2Manager", @"invalid_request");
+        } else if ([[object valueForKey:@"error"] isEqualToString:@"unsupported_grant_type"]) {
+            description = NSLocalizedStringFromTable(@"The authorization grant type is not supported by the authorization server.", @"AFOAuth2Manager", @"invalid_request");
+        }
+    }
+
+    if (description) {
+        mutableUserInfo[NSLocalizedDescriptionKey] = description;
+    }
+
+    if ([object valueForKey:@"error_uri"]) {
+        mutableUserInfo[NSLocalizedRecoverySuggestionErrorKey] = [object valueForKey:@"error_uri"];
+    }
+
+    return [NSError errorWithDomain:AFOAuth2ErrorDomain code:-1 userInfo:mutableUserInfo];
+}

--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -1,6 +1,6 @@
 // AFOAuth2Manager.h
 //
-// Copyright (c) 2012-2014 AFNetworking (http://afnetworking.com)
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,7 @@
 #import <Foundation/Foundation.h>
 
 #import "AFHTTPRequestOperationManager.h"
-
-@class AFOAuthCredential;
+#import "AFOAuthCredential.h"
 
 /**
  `AFOAuth2Manager` encapsulates common patterns to authenticate against a resource server conforming to the behavior outlined in the OAuth 2.0 specification.
@@ -99,11 +98,11 @@
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                   username:(NSString *)username
-                                   password:(NSString *)password
-                                      scope:(NSString *)scope
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure;
+                                                       username:(NSString *)username
+                                                       password:(NSString *)password
+                                                          scope:(NSString *)scope
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server with a designated scope.
@@ -114,9 +113,9 @@
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                      scope:(NSString *)scope
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure;
+                                                          scope:(NSString *)scope
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server using the specified refresh token.
@@ -127,9 +126,9 @@
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                               refreshToken:(NSString *)refreshToken
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure;
+                                                   refreshToken:(NSString *)refreshToken
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server with an authorization code, redirecting to a specified URI upon successful authentication.
@@ -141,10 +140,10 @@
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                       code:(NSString *)code
-                                redirectURI:(NSString *)uri
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure;
+                                                           code:(NSString *)code
+                                                    redirectURI:(NSString *)uri
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server with the specified parameters.
@@ -155,144 +154,13 @@
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                 parameters:(NSDictionary *)parameters
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure;
+                                                     parameters:(NSDictionary *)parameters
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure;
 
 @end
 
 #pragma mark -
-
-/**
- `AFOAuthCredential` models the credentials returned from an OAuth server, storing the token type, access & refresh tokens, and whether the token is expired.
-
- OAuth credentials can be stored in the user's keychain, and retrieved on subsequent launches.
- */
-@interface AFOAuthCredential : NSObject <NSCoding>
-
-///--------------------------------------
-/// @name Accessing Credential Properties
-///--------------------------------------
-
-/**
- The OAuth access token.
- */
-@property (readonly, nonatomic, copy) NSString *accessToken;
-
-/**
- The OAuth token type (e.g. "bearer").
- */
-@property (readonly, nonatomic, copy) NSString *tokenType;
-
-/**
- The OAuth refresh token.
- */
-@property (readonly, nonatomic, copy) NSString *refreshToken;
-
-/**
- Whether the OAuth credentials are expired.
- */
-@property (readonly, nonatomic, assign, getter = isExpired) BOOL expired;
-
-///--------------------------------------------
-/// @name Creating and Initializing Credentials
-///--------------------------------------------
-
-/**
- Create an OAuth credential from a token string, with a specified type.
-
- @param token The OAuth token string.
- @param type The OAuth token type.
- */
-+ (instancetype)credentialWithOAuthToken:(NSString *)token
-                               tokenType:(NSString *)type;
-
-/**
- Initialize an OAuth credential from a token string, with a specified type.
-
- @param token The OAuth token string.
- @param type The OAuth token type.
- */
-- (id)initWithOAuthToken:(NSString *)token
-               tokenType:(NSString *)type;
-
-///----------------------------
-/// @name Setting Refresh Token
-///----------------------------
-
-/**
- Set the credential refresh token, without a specific expiration
-
- @param refreshToken The OAuth refresh token.
- */
-- (void)setRefreshToken:(NSString *)refreshToken;
-
-
-/**
- Set the expiration on the access token. If no expiration is given by the OAuth2 provider,
- you may pass in [NSDate distantFuture]
-
- @param expiration The expiration of the access token. This must not be `nil`.
- */
-- (void)setExpiration:(NSDate *)expiration;
-
-/**
- Set the credential refresh token, with a specified expiration.
-
- @param refreshToken The OAuth refresh token.
- @param expiration The expiration of the access token. This must not be `nil`.
- */
-- (void)setRefreshToken:(NSString *)refreshToken
-             expiration:(NSDate *)expiration;
-
-///-----------------------------------------
-/// @name Storing and Retrieving Credentials
-///-----------------------------------------
-
-/**
- Stores the specified OAuth credential for a given web service identifier in the Keychain.
- with the default Keychain Accessibilty of kSecAttrAccessibleWhenUnlocked.
-
- @param credential The OAuth credential to be stored.
- @param identifier The service identifier associated with the specified credential.
-
- @return Whether or not the credential was stored in the keychain.
- */
-+ (BOOL)storeCredential:(AFOAuthCredential *)credential
-         withIdentifier:(NSString *)identifier;
-
-/**
- Stores the specified OAuth token for a given web service identifier in the Keychain.
-
- @param credential The OAuth credential to be stored.
- @param identifier The service identifier associated with the specified token.
- @param securityAccessibility The Keychain security accessibility to store the credential with.
-
- @return Whether or not the credential was stored in the keychain.
- */
-+ (BOOL)storeCredential:(AFOAuthCredential *)credential
-         withIdentifier:(NSString *)identifier
-      withAccessibility:(id)securityAccessibility;
-
-/**
- Retrieves the OAuth credential stored with the specified service identifier from the Keychain.
-
- @param identifier The service identifier associated with the specified credential.
-
- @return The retrieved OAuth credential.
- */
-+ (AFOAuthCredential *)retrieveCredentialWithIdentifier:(NSString *)identifier;
-
-/**
- Deletes the OAuth credential stored with the specified service identifier from the Keychain.
-
- @param identifier The service identifier associated with the specified credential.
-
- @return Whether or not the credential was deleted from the keychain.
- */
-+ (BOOL)deleteCredentialWithIdentifier:(NSString *)identifier;
-
-@end
 
 ///----------------
 /// @name Constants

--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -79,9 +79,9 @@
 
  @return The newly-initialized OAuth 2 client
  */
-- (id)initWithBaseURL:(NSURL *)url
-             clientID:(NSString *)clientID
-               secret:(NSString *)secret;
+- (instancetype)initWithBaseURL:(NSURL *)url
+                       clientID:(NSString *)clientID
+                         secret:(NSString *)secret;
 
 ///---------------------
 /// @name Authenticating
@@ -161,33 +161,6 @@
 @end
 
 #pragma mark -
-
-///----------------
-/// @name Constants
-///----------------
-
-/**
- ## Error Domains
-
- The following error domain is predefined.
-
- - `NSString * const AFOAuth2ErrorDomain`
-
- ## OAuth Grant Types
-
- OAuth 2.0 provides several grant types, covering several different use cases. The following grant type string constants are provided:
-
- `kAFOAuthCodeGrantType`: "authorization_code"
- `kAFOAuthClientCredentialsGrantType`: "client_credentials"
- `kAFOAuthPasswordCredentialsGrantType`: "password"
- `kAFOAuthRefreshGrantType`: "refresh_token"
- */
-extern NSString * const AFOAuth2ErrorDomain;
-
-extern NSString * const kAFOAuthCodeGrantType;
-extern NSString * const kAFOAuthClientCredentialsGrantType;
-extern NSString * const kAFOAuthPasswordCredentialsGrantType;
-extern NSString * const kAFOAuthRefreshGrantType;
 
 @compatibility_alias AFOAuth2Client AFOAuth2Manager;
 @compatibility_alias AFOAuth2RequestOperationManager AFOAuth2Manager;

--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -22,7 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "AFHTTPRequestOperationManager.h"
+#import <AFNetworking/AFHTTPRequestOperationManager.h>
 #import "AFOAuthCredential.h"
 
 /**

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -98,7 +98,7 @@
                                  @"username": username,
                                  @"password": password,
                                  @"scope": scope
-                                 };
+                                };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
@@ -113,7 +113,7 @@
     NSDictionary *parameters = @{
                                  @"grant_type": kAFOAuthClientCredentialsGrantType,
                                  @"scope": scope
-                                 };
+                                };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
@@ -128,7 +128,7 @@
     NSDictionary *parameters = @{
                                  @"grant_type": kAFOAuthRefreshGrantType,
                                  @"refresh_token": refreshToken
-                                 };
+                                };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
@@ -198,11 +198,11 @@
         if (expiresIn && ![expiresIn isEqual:[NSNull null]]) {
             expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
         }
-        
+
         if (expireDate) {
             [credential setExpiration:expireDate];
         }
-        
+
         if (success) {
             success(credential);
         }
@@ -211,7 +211,7 @@
             failure(error);
         }
     }];
-    
+
     return requestOperation;
 }
 

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -1,6 +1,6 @@
 // AFOAuth2Manager.m
 //
-// Copyright (c) 2012-2014 AFNetworking (http://afnetworking.com)
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Security/Security.h>
-
 #import "AFOAuth2Manager.h"
 
 NSString * const AFOAuth2ErrorDomain = @"com.alamofire.networking.oauth2.error";
@@ -30,18 +28,6 @@ NSString * const kAFOAuthCodeGrantType = @"authorization_code";
 NSString * const kAFOAuthClientCredentialsGrantType = @"client_credentials";
 NSString * const kAFOAuthPasswordCredentialsGrantType = @"password";
 NSString * const kAFOAuthRefreshGrantType = @"refresh_token";
-
-NSString * const kAFOAuth2CredentialServiceName = @"AFOAuthCredentialService";
-
-static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifier) {
-    NSCParameterAssert(identifier);
-
-    return @{
-      (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
-      (__bridge id)kSecAttrService: kAFOAuth2CredentialServiceName,
-      (__bridge id)kSecAttrAccount: identifier
-    };
-}
 
 // See: http://tools.ietf.org/html/rfc6749#section-5.2
 static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
@@ -106,7 +92,7 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     if (!self) {
         return nil;
     }
-    
+
     self.serviceProviderIdentifier = [self.baseURL host];
     self.clientID = clientID;
     self.secret = secret;
@@ -114,7 +100,7 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     self.useHTTPBasicAuthentication = YES;
 
     [self.requestSerializer setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-    
+
     return self;
 }
 
@@ -141,11 +127,11 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 #pragma mark -
 
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                   username:(NSString *)username
-                                   password:(NSString *)password
-                                      scope:(NSString *)scope
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure
+                                                       username:(NSString *)username
+                                                       password:(NSString *)password
+                                                          scope:(NSString *)scope
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(username);
     NSParameterAssert(password);
@@ -156,46 +142,46 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                  @"username": username,
                                  @"password": password,
                                  @"scope": scope
-                                };
+                                 };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                      scope:(NSString *)scope
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure
+                                                          scope:(NSString *)scope
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(scope);
 
     NSDictionary *parameters = @{
                                  @"grant_type": kAFOAuthClientCredentialsGrantType,
                                  @"scope": scope
-                                };
+                                 };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                               refreshToken:(NSString *)refreshToken
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure
+                                                   refreshToken:(NSString *)refreshToken
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(refreshToken);
 
     NSDictionary *parameters = @{
                                  @"grant_type": kAFOAuthRefreshGrantType,
                                  @"refresh_token": refreshToken
-                                };
+                                 };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                       code:(NSString *)code
-                                redirectURI:(NSString *)uri
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure
+                                                           code:(NSString *)code
+                                                    redirectURI:(NSString *)uri
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(code);
     NSParameterAssert(uri);
@@ -204,15 +190,15 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                  @"grant_type": kAFOAuthCodeGrantType,
                                  @"code": code,
                                  @"redirect_uri": uri
-                                };
+                                 };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
 
 - (AFHTTPRequestOperation *)authenticateUsingOAuthWithURLString:(NSString *)URLString
-                                 parameters:(NSDictionary *)parameters
-                                    success:(void (^)(AFOAuthCredential *credential))success
-                                    failure:(void (^)(NSError *error))failure
+                                                     parameters:(NSDictionary *)parameters
+                                                        success:(void (^)(AFOAuthCredential *credential))success
+                                                        failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     if (!self.useHTTPBasicAuthentication) {
@@ -256,11 +242,11 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
         if (expiresIn && ![expiresIn isEqual:[NSNull null]]) {
             expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
         }
-
+        
         if (expireDate) {
             [credential setExpiration:expireDate];
         }
-
+        
         if (success) {
             success(credential);
         }
@@ -271,166 +257,6 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     }];
     
     return requestOperation;
-}
-
-@end
-
-#pragma mark -
-
-@interface AFOAuthCredential ()
-@property (readwrite, nonatomic, copy) NSString *accessToken;
-@property (readwrite, nonatomic, copy) NSString *tokenType;
-@property (readwrite, nonatomic, copy) NSString *refreshToken;
-@property (readwrite, nonatomic, copy) NSDate *expiration;
-@end
-
-@implementation AFOAuthCredential
-@dynamic expired;
-
-#pragma mark -
-
-+ (instancetype)credentialWithOAuthToken:(NSString *)token
-                               tokenType:(NSString *)type
-{
-    return [[self alloc] initWithOAuthToken:token tokenType:type];
-}
-
-- (id)initWithOAuthToken:(NSString *)token
-               tokenType:(NSString *)type
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-
-    self.accessToken = token;
-    self.tokenType = type;
-
-    return self;
-}
-
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<%@ accessToken:\"%@\" tokenType:\"%@\" refreshToken:\"%@\" expiration:\"%@\">", [self class], self.accessToken, self.tokenType, self.refreshToken, self.expiration];
-}
-
-- (void)setRefreshToken:(NSString *)refreshToken
-{
-    _refreshToken = refreshToken;
-}
-
-- (void)setExpiration:(NSDate *)expiration
-{
-    _expiration = expiration;
-}
-
-- (void)setRefreshToken:(NSString *)refreshToken
-             expiration:(NSDate *)expiration
-{
-    NSParameterAssert(refreshToken);
-    NSParameterAssert(expiration);
-
-    self.refreshToken = refreshToken;
-    self.expiration = expiration;
-}
-
-- (BOOL)isExpired {
-    return [self.expiration compare:[NSDate date]] == NSOrderedAscending;
-}
-
-#pragma mark Keychain
-
-+ (BOOL)storeCredential:(AFOAuthCredential *)credential
-         withIdentifier:(NSString *)identifier
-{
-    id securityAccessibility = nil;
-#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 43000) || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090)
-    if (&kSecAttrAccessibleWhenUnlocked != NULL) {
-        securityAccessibility = (__bridge id)kSecAttrAccessibleWhenUnlocked;
-    }
-#endif
-
-    return [[self class] storeCredential:credential withIdentifier:identifier withAccessibility:securityAccessibility];
-}
-
-+ (BOOL)storeCredential:(AFOAuthCredential *)credential
-         withIdentifier:(NSString *)identifier
-      withAccessibility:(id)securityAccessibility
-{
-    NSMutableDictionary *queryDictionary = [AFKeychainQueryDictionaryWithIdentifier(identifier) mutableCopy];
-
-    if (!credential) {
-        return [self deleteCredentialWithIdentifier:identifier];
-    }
-
-    NSMutableDictionary *updateDictionary = [NSMutableDictionary dictionary];
-    updateDictionary[(__bridge id)kSecValueData] = [NSKeyedArchiver archivedDataWithRootObject:credential];
-
-    if (securityAccessibility) {
-        updateDictionary[(__bridge id)kSecAttrAccessible] = securityAccessibility;
-    }
-
-    OSStatus status;
-    BOOL exists = ([self retrieveCredentialWithIdentifier:identifier] != nil);
-
-    if (exists) {
-        status = SecItemUpdate((__bridge CFDictionaryRef)queryDictionary, (__bridge CFDictionaryRef)updateDictionary);
-    } else {
-        [queryDictionary addEntriesFromDictionary:updateDictionary];
-        status = SecItemAdd((__bridge CFDictionaryRef)queryDictionary, NULL);
-    }
-
-    if (status != errSecSuccess) {
-        NSLog(@"Unable to %@ credential with identifier \"%@\" (Error %li)", exists ? @"update" : @"add", identifier, (long int)status);
-    }
-
-    return (status == errSecSuccess);
-}
-
-+ (BOOL)deleteCredentialWithIdentifier:(NSString *)identifier {
-    NSMutableDictionary *queryDictionary = [AFKeychainQueryDictionaryWithIdentifier(identifier) mutableCopy];
-
-    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)queryDictionary);
-
-    if (status != errSecSuccess) {
-        NSLog(@"Unable to delete credential with identifier \"%@\" (Error %li)", identifier, (long int)status);
-    }
-
-    return (status == errSecSuccess);
-}
-
-+ (AFOAuthCredential *)retrieveCredentialWithIdentifier:(NSString *)identifier {
-    NSMutableDictionary *queryDictionary = [AFKeychainQueryDictionaryWithIdentifier(identifier) mutableCopy];
-    queryDictionary[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
-    queryDictionary[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
-
-    CFDataRef result = nil;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)queryDictionary, (CFTypeRef *)&result);
-
-    if (status != errSecSuccess) {
-        NSLog(@"Unable to fetch credential with identifier \"%@\" (Error %li)", identifier, (long int)status);
-        return nil;
-    }
-
-    return [NSKeyedUnarchiver unarchiveObjectWithData:(__bridge_transfer NSData *)result];
-}
-
-#pragma mark - NSCoding
-
-- (id)initWithCoder:(NSCoder *)decoder {
-    self = [super init];
-    self.accessToken = [decoder decodeObjectForKey:NSStringFromSelector(@selector(accessToken))];
-    self.tokenType = [decoder decodeObjectForKey:NSStringFromSelector(@selector(tokenType))];
-    self.refreshToken = [decoder decodeObjectForKey:NSStringFromSelector(@selector(refreshToken))];
-    self.expiration = [decoder decodeObjectForKey:NSStringFromSelector(@selector(expiration))];
-
-    return self;
-}
-
-- (void)encodeWithCoder:(NSCoder *)encoder {
-    [encoder encodeObject:self.accessToken forKey:NSStringFromSelector(@selector(accessToken))];
-    [encoder encodeObject:self.tokenType forKey:NSStringFromSelector(@selector(tokenType))];
-    [encoder encodeObject:self.refreshToken forKey:NSStringFromSelector(@selector(refreshToken))];
-    [encoder encodeObject:self.expiration forKey:NSStringFromSelector(@selector(expiration))];
 }
 
 @end

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -21,51 +21,7 @@
 // THE SOFTWARE.
 
 #import "AFOAuth2Manager.h"
-
-NSString * const AFOAuth2ErrorDomain = @"com.alamofire.networking.oauth2.error";
-
-NSString * const kAFOAuthCodeGrantType = @"authorization_code";
-NSString * const kAFOAuthClientCredentialsGrantType = @"client_credentials";
-NSString * const kAFOAuthPasswordCredentialsGrantType = @"password";
-NSString * const kAFOAuthRefreshGrantType = @"refresh_token";
-
-// See: http://tools.ietf.org/html/rfc6749#section-5.2
-static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
-    if (![object valueForKey:@"error"] || [[object valueForKey:@"error"] isEqual:[NSNull null]]) {
-        return nil;
-    }
-
-    NSMutableDictionary *mutableUserInfo = [NSMutableDictionary dictionary];
-
-    NSString *description = nil;
-    if ([object valueForKey:@"error_description"]) {
-        description = [object valueForKey:@"error_description"];
-    } else {
-        if ([[object valueForKey:@"error"] isEqualToString:@"invalid_request"]) {
-            description = NSLocalizedStringFromTable(@"The request is missing a required parameter, includes an unsupported parameter value (other than grant type), repeats a parameter, includes multiple credentials, utilizes more than one mechanism for authenticating the client, or is otherwise malformed.", @"AFOAuth2Manager", @"invalid_request");
-        } else if ([[object valueForKey:@"error"] isEqualToString:@"invalid_client"]) {
-            description = NSLocalizedStringFromTable(@"Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method).  The authorization server MAY return an HTTP 401 (Unauthorized) status code to indicate which HTTP authentication schemes are supported.  If the client attempted to authenticate via the \"Authorization\" request header field, the authorization server MUST respond with an HTTP 401 (Unauthorized) status code and include the \"WWW-Authenticate\" response header field matching the authentication scheme used by the client.", @"AFOAuth2Manager", @"invalid_request");
-        } else if ([[object valueForKey:@"error"] isEqualToString:@"invalid_grant"]) {
-            description = NSLocalizedStringFromTable(@"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.", @"AFOAuth2Manager", @"invalid_request");
-        } else if ([[object valueForKey:@"error"] isEqualToString:@"unauthorized_client"]) {
-            description = NSLocalizedStringFromTable(@"The authenticated client is not authorized to use this authorization grant type.", @"AFOAuth2Manager", @"invalid_request");
-        } else if ([[object valueForKey:@"error"] isEqualToString:@"unsupported_grant_type"]) {
-            description = NSLocalizedStringFromTable(@"The authorization grant type is not supported by the authorization server.", @"AFOAuth2Manager", @"invalid_request");
-        }
-    }
-
-    if (description) {
-        mutableUserInfo[NSLocalizedDescriptionKey] = description;
-    }
-
-    if ([object valueForKey:@"error_uri"]) {
-        mutableUserInfo[NSLocalizedRecoverySuggestionErrorKey] = [object valueForKey:@"error_uri"];
-    }
-
-    return [NSError errorWithDomain:AFOAuth2ErrorDomain code:-1 userInfo:mutableUserInfo];
-}
-
-#pragma mark -
+#import "AFOAuth2Constants.h"
 
 @interface AFOAuth2Manager ()
 @property (readwrite, nonatomic, copy) NSString *serviceProviderIdentifier;
@@ -82,9 +38,9 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     return [[self alloc] initWithBaseURL:url clientID:clientID secret:secret];
 }
 
-- (id)initWithBaseURL:(NSURL *)url
-             clientID:(NSString *)clientID
-               secret:(NSString *)secret
+- (instancetype)initWithBaseURL:(NSURL *)url
+                       clientID:(NSString *)clientID
+                         secret:(NSString *)secret
 {
     NSParameterAssert(clientID);
 

--- a/AFOAuth2Manager/AFOAuth2SessionManager.h
+++ b/AFOAuth2Manager/AFOAuth2SessionManager.h
@@ -24,9 +24,9 @@
 #import "AFOAuthCredential.h"
 
 /**
- `AFOAuth2Manager` encapsulates common patterns to authenticate against a resource server conforming to the behavior outlined in the OAuth 2.0 specification.
+ `AFOAuth2SessionManager` encapsulates common patterns to authenticate against a resource server conforming to the behavior outlined in the OAuth 2.0 specification.
 
- In your application, it is recommended that you use `AFOAuth2Manager` exclusively to get an authorization token, which is then passed to another `AFHTTPClient` subclass.
+ In your application, it is recommended that you use `AFOAuth2SessionManager` exclusively to get an authorization token, which is then passed to another `AFHTTPSessionManager` subclass.
 
  @see RFC 6749 The OAuth 2.0 Authorization Framework: http://tools.ietf.org/html/rfc6749
  */

--- a/AFOAuth2Manager/AFOAuth2SessionManager.h
+++ b/AFOAuth2Manager/AFOAuth2SessionManager.h
@@ -1,0 +1,190 @@
+// AFOAuth2SessionManager.h
+//
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFHTTPSessionManager.h"
+#import "AFOAuthCredential.h"
+
+/**
+ `AFOAuth2Manager` encapsulates common patterns to authenticate against a resource server conforming to the behavior outlined in the OAuth 2.0 specification.
+
+ In your application, it is recommended that you use `AFOAuth2Manager` exclusively to get an authorization token, which is then passed to another `AFHTTPClient` subclass.
+
+ @see RFC 6749 The OAuth 2.0 Authorization Framework: http://tools.ietf.org/html/rfc6749
+ */
+@interface AFOAuth2SessionManager : AFHTTPSessionManager
+
+///------------------------------------------
+/// @name Accessing OAuth 2 Client Properties
+///------------------------------------------
+
+/**
+ The service provider identifier used to store and retrieve OAuth credentials by `AFOAuthCredential`. Equivalent to the hostname of the client `baseURL`.
+ */
+@property (readonly, nonatomic, copy) NSString *serviceProviderIdentifier;
+
+/**
+ The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
+ */
+@property (readonly, nonatomic, copy) NSString *clientID;
+
+/**
+ Whether to encode client credentials in a Base64-encoded HTTP `Authorization` header, as opposed to the request body. Defaults to `YES`.
+ */
+@property (nonatomic, assign) BOOL useHTTPBasicAuthentication;
+
+///------------------------------------------------
+/// @name Creating and Initializing OAuth 2 Clients
+///------------------------------------------------
+
+/**
+ Creates and initializes an `AFOAuth2SessionManager` object with the specified base URL, client identifier, and secret.
+
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+ @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client. This argument must not be `nil`.
+ @param secret The client secret.
+
+ @return The newly-initialized OAuth 2 client
+ */
++ (instancetype)clientWithBaseURL:(NSURL *)url
+                         clientID:(NSString *)clientID
+                           secret:(NSString *)secret;
+
+/**
+ Creates and initializes an `AFOAuth2SessionManager` object with the specified base URL, client identifier, and secret.
+
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+ @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client. This argument must not be `nil`.
+ @param secret The client secret.
+ @param configuration The configuration used to create the managed session.
+
+ @return The newly-initialized OAuth 2 client
+ */
++ (instancetype)clientWithBaseURL:(NSURL *)url
+                         clientID:(NSString *)clientID
+                           secret:(NSString *)secret
+             sessionConfiguration:(NSURLSessionConfiguration *)configuration;
+
+
+/**
+ Initializes an `AFOAuth2SessionManager` object with the specified base URL, client identifier, and secret. The communication to to the server will use HTTP basic auth by default (use `-(id)initWithBaseURL:clientID:secret:withBasicAuth:` to change this).
+
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+ @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client. This argument must not be `nil`.
+ @param secret The client secret.
+
+ @return The newly-initialized OAuth 2 client
+ */
+- (instancetype)initWithBaseURL:(NSURL *)url
+                       clientID:(NSString *)clientID
+                         secret:(NSString *)secret;
+
+/**
+ Initializes an `AFOAuth2SessionManager` object with the specified base URL, client identifier, and secret. The communication to to the server will use HTTP basic auth by default (use `-(id)initWithBaseURL:clientID:secret:withBasicAuth:` to change this).
+
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+ @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client. This argument must not be `nil`.
+ @param secret The client secret.
+ @param configuration The configuration used to create the managed session.
+
+ @return The newly-initialized OAuth 2 client
+ */
+- (instancetype)initWithBaseURL:(NSURL *)url
+                       clientID:(NSString *)clientID
+                         secret:(NSString *)secret
+           sessionConfiguration:(NSURLSessionConfiguration *)configuration;
+
+///---------------------
+/// @name Authenticating
+///---------------------
+
+/**
+ Creates and enqueues an `NSURLSessionDataTask` to authenticate against the server using a specified username and password, with a designated scope.
+
+ @param URLString The URL string used to create the request URL.
+ @param username The username used for authentication
+ @param password The password used for authentication
+ @param scope The authorization scope
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ */
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                     username:(NSString *)username
+                                                     password:(NSString *)password
+                                                        scope:(NSString *)scope
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Creates and enqueues an `NSURLSessionDataTask` to authenticate against the server with a designated scope.
+
+ @param URLString The URL string used to create the request URL.
+ @param scope The authorization scope
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ */
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                        scope:(NSString *)scope
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Creates and enqueues an `NSURLSessionDataTask` to authenticate against the server using the specified refresh token.
+
+ @param URLString The URL string used to create the request URL.
+ @param refreshToken The OAuth refresh token
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ */
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                 refreshToken:(NSString *)refreshToken
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Creates and enqueues an `NSURLSessionDataTask` to authenticate against the server with an authorization code, redirecting to a specified URI upon successful authentication.
+
+ @param URLString The URL string used to create the request URL.
+ @param code The authorization code
+ @param uri The URI to redirect to after successful authentication
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ */
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                         code:(NSString *)code
+                                                  redirectURI:(NSString *)uri
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure;
+
+/**
+ Creates and enqueues an `NSURLSessionDataTask` to authenticate against the server with the specified parameters.
+
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ */
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                   parameters:(NSDictionary *)parameters
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure;
+
+@end

--- a/AFOAuth2Manager/AFOAuth2SessionManager.h
+++ b/AFOAuth2Manager/AFOAuth2SessionManager.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPSessionManager.h"
+#import <AFNetworking/AFHTTPSessionManager.h>
 #import "AFOAuthCredential.h"
 
 /**

--- a/AFOAuth2Manager/AFOAuth2SessionManager.m
+++ b/AFOAuth2Manager/AFOAuth2SessionManager.m
@@ -114,7 +114,7 @@
                                  @"username": username,
                                  @"password": password,
                                  @"scope": scope
-                                 };
+                                };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
@@ -129,7 +129,7 @@
     NSDictionary *parameters = @{
                                  @"grant_type": kAFOAuthClientCredentialsGrantType,
                                  @"scope": scope
-                                 };
+                                };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
@@ -144,7 +144,7 @@
     NSDictionary *parameters = @{
                                  @"grant_type": kAFOAuthRefreshGrantType,
                                  @"refresh_token": refreshToken
-                                 };
+                                };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
@@ -162,7 +162,7 @@
                                  @"grant_type": kAFOAuthCodeGrantType,
                                  @"code": code,
                                  @"redirect_uri": uri
-                                 };
+                                };
 
     return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
 }
@@ -218,7 +218,7 @@
         if (expireDate) {
             [credential setExpiration:expireDate];
         }
-        
+
         if (success) {
             success(credential);
         }
@@ -227,7 +227,7 @@
             failure(error);
         }
     }];
-    
+
     return task;
 }
 

--- a/AFOAuth2Manager/AFOAuth2SessionManager.m
+++ b/AFOAuth2Manager/AFOAuth2SessionManager.m
@@ -1,0 +1,234 @@
+// AFOAuth2SessionManager.m
+//
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "AFOAuth2SessionManager.h"
+#import "AFOAuth2Constants.h"
+
+@interface AFOAuth2SessionManager ()
+@property (readwrite, nonatomic, copy) NSString *serviceProviderIdentifier;
+@property (readwrite, nonatomic, copy) NSString *clientID;
+@property (readwrite, nonatomic, copy) NSString *secret;
+@end
+
+@implementation AFOAuth2SessionManager
+
++ (instancetype)clientWithBaseURL:(NSURL *)url
+                         clientID:(NSString *)clientID
+                           secret:(NSString *)secret
+{
+    return [[self alloc] initWithBaseURL:url clientID:clientID secret:secret sessionConfiguration:nil];
+}
+
++ (instancetype)clientWithBaseURL:(NSURL *)url
+                         clientID:(NSString *)clientID
+                           secret:(NSString *)secret
+             sessionConfiguration:(NSURLSessionConfiguration *)configuration
+{
+    return [[self alloc] initWithBaseURL:url clientID:clientID secret:secret sessionConfiguration:configuration];
+}
+
+- (instancetype)initWithBaseURL:(NSURL *)url
+                       clientID:(NSString *)clientID
+                         secret:(NSString *)secret
+{
+    return [self initWithBaseURL:url clientID:clientID secret:secret sessionConfiguration:nil];
+}
+
+- (instancetype)initWithBaseURL:(NSURL *)url
+                       clientID:(NSString *)clientID
+                         secret:(NSString *)secret
+           sessionConfiguration:(NSURLSessionConfiguration *)configuration
+{
+    NSParameterAssert(clientID);
+
+    self = [super initWithBaseURL:url sessionConfiguration:configuration];
+    if (!self) {
+        return nil;
+    }
+
+    self.serviceProviderIdentifier = [self.baseURL host];
+    self.clientID = clientID;
+    self.secret = secret;
+
+    self.useHTTPBasicAuthentication = YES;
+
+    [self.requestSerializer setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+
+    return self;
+}
+
+#pragma mark -
+
+- (void)setUseHTTPBasicAuthentication:(BOOL)useHTTPBasicAuthentication {
+    _useHTTPBasicAuthentication = useHTTPBasicAuthentication;
+
+    if (self.useHTTPBasicAuthentication) {
+        [self.requestSerializer setAuthorizationHeaderFieldWithUsername:self.clientID password:self.secret];
+    } else {
+        [self.requestSerializer setValue:nil forHTTPHeaderField:@"Authorization"];
+    }
+}
+
+- (void)setSecret:(NSString *)secret {
+    if (!secret) {
+        secret = @"";
+    }
+
+    _secret = secret;
+}
+
+#pragma mark -
+
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                     username:(NSString *)username
+                                                     password:(NSString *)password
+                                                        scope:(NSString *)scope
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure
+{
+    NSParameterAssert(username);
+    NSParameterAssert(password);
+    NSParameterAssert(scope);
+
+    NSDictionary *parameters = @{
+                                 @"grant_type": kAFOAuthPasswordCredentialsGrantType,
+                                 @"username": username,
+                                 @"password": password,
+                                 @"scope": scope
+                                 };
+
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+}
+
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                        scope:(NSString *)scope
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure
+{
+    NSParameterAssert(scope);
+
+    NSDictionary *parameters = @{
+                                 @"grant_type": kAFOAuthClientCredentialsGrantType,
+                                 @"scope": scope
+                                 };
+
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+}
+
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                 refreshToken:(NSString *)refreshToken
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure
+{
+    NSParameterAssert(refreshToken);
+
+    NSDictionary *parameters = @{
+                                 @"grant_type": kAFOAuthRefreshGrantType,
+                                 @"refresh_token": refreshToken
+                                 };
+
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+}
+
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                         code:(NSString *)code
+                                                  redirectURI:(NSString *)uri
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure
+{
+    NSParameterAssert(code);
+    NSParameterAssert(uri);
+
+    NSDictionary *parameters = @{
+                                 @"grant_type": kAFOAuthCodeGrantType,
+                                 @"code": code,
+                                 @"redirect_uri": uri
+                                 };
+
+    return [self authenticateUsingOAuthWithURLString:URLString parameters:parameters success:success failure:failure];
+}
+
+- (NSURLSessionDataTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
+                                                   parameters:(NSDictionary *)parameters
+                                                      success:(void (^)(AFOAuthCredential *credential))success
+                                                      failure:(void (^)(NSError *error))failure
+{
+    NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
+    if (!self.useHTTPBasicAuthentication) {
+        mutableParameters[@"client_id"] = self.clientID;
+        mutableParameters[@"client_secret"] = self.secret;
+    }
+    parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
+
+    NSURLSessionDataTask *task = [self POST:URLString parameters:parameters success:^(__unused NSURLSessionDataTask *task, id responseObject) {
+        if (!responseObject) {
+            if (failure) {
+                failure(nil);
+            }
+
+            return;
+        }
+
+        if ([responseObject valueForKey:@"error"]) {
+            if (failure) {
+                failure(AFErrorFromRFC6749Section5_2Error(responseObject));
+            }
+
+            return;
+        }
+
+        NSString *refreshToken = [responseObject valueForKey:@"refresh_token"];
+        if (!refreshToken || [refreshToken isEqual:[NSNull null]]) {
+            refreshToken = [parameters valueForKey:@"refresh_token"];
+        }
+
+        AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
+
+
+        if (refreshToken) { // refreshToken is optional in the OAuth2 spec
+            [credential setRefreshToken:refreshToken];
+        }
+
+        // Expiration is optional, but recommended in the OAuth2 spec. It not provide, assume distantFuture === never expires
+        NSDate *expireDate = [NSDate distantFuture];
+        id expiresIn = [responseObject valueForKey:@"expires_in"];
+        if (expiresIn && ![expiresIn isEqual:[NSNull null]]) {
+            expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
+        }
+
+        if (expireDate) {
+            [credential setExpiration:expireDate];
+        }
+        
+        if (success) {
+            success(credential);
+        }
+    } failure:^(__unused NSURLSessionDataTask *task, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+    
+    return task;
+}
+
+@end

--- a/AFOAuth2Manager/AFOAuthCredential.h
+++ b/AFOAuth2Manager/AFOAuthCredential.h
@@ -1,0 +1,154 @@
+// AFOAuthCredential.h
+//
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+/**
+ `AFOAuthCredential` models the credentials returned from an OAuth server, storing the token type, access & refresh tokens, and whether the token is expired.
+
+ OAuth credentials can be stored in the user's keychain, and retrieved on subsequent launches.
+ */
+@interface AFOAuthCredential : NSObject <NSCoding>
+
+///--------------------------------------
+/// @name Accessing Credential Properties
+///--------------------------------------
+
+/**
+ The OAuth access token.
+ */
+@property (readonly, nonatomic, copy) NSString *accessToken;
+
+/**
+ The OAuth token type (e.g. "bearer").
+ */
+@property (readonly, nonatomic, copy) NSString *tokenType;
+
+/**
+ The OAuth refresh token.
+ */
+@property (readonly, nonatomic, copy) NSString *refreshToken;
+
+/**
+ Whether the OAuth credentials are expired.
+ */
+@property (readonly, nonatomic, assign, getter = isExpired) BOOL expired;
+
+///--------------------------------------------
+/// @name Creating and Initializing Credentials
+///--------------------------------------------
+
+/**
+ Create an OAuth credential from a token string, with a specified type.
+
+ @param token The OAuth token string.
+ @param type The OAuth token type.
+ */
++ (instancetype)credentialWithOAuthToken:(NSString *)token
+                               tokenType:(NSString *)type;
+
+/**
+ Initialize an OAuth credential from a token string, with a specified type.
+
+ @param token The OAuth token string.
+ @param type The OAuth token type.
+ */
+- (id)initWithOAuthToken:(NSString *)token
+               tokenType:(NSString *)type;
+
+///----------------------------
+/// @name Setting Refresh Token
+///----------------------------
+
+/**
+ Set the credential refresh token, without a specific expiration
+
+ @param refreshToken The OAuth refresh token.
+ */
+- (void)setRefreshToken:(NSString *)refreshToken;
+
+
+/**
+ Set the expiration on the access token. If no expiration is given by the OAuth2 provider,
+ you may pass in [NSDate distantFuture]
+
+ @param expiration The expiration of the access token. This must not be `nil`.
+ */
+- (void)setExpiration:(NSDate *)expiration;
+
+/**
+ Set the credential refresh token, with a specified expiration.
+
+ @param refreshToken The OAuth refresh token.
+ @param expiration The expiration of the access token. This must not be `nil`.
+ */
+- (void)setRefreshToken:(NSString *)refreshToken
+             expiration:(NSDate *)expiration;
+
+///-----------------------------------------
+/// @name Storing and Retrieving Credentials
+///-----------------------------------------
+
+/**
+ Stores the specified OAuth credential for a given web service identifier in the Keychain.
+ with the default Keychain Accessibilty of kSecAttrAccessibleWhenUnlocked.
+
+ @param credential The OAuth credential to be stored.
+ @param identifier The service identifier associated with the specified credential.
+
+ @return Whether or not the credential was stored in the keychain.
+ */
++ (BOOL)storeCredential:(AFOAuthCredential *)credential
+         withIdentifier:(NSString *)identifier;
+
+/**
+ Stores the specified OAuth token for a given web service identifier in the Keychain.
+
+ @param credential The OAuth credential to be stored.
+ @param identifier The service identifier associated with the specified token.
+ @param securityAccessibility The Keychain security accessibility to store the credential with.
+
+ @return Whether or not the credential was stored in the keychain.
+ */
++ (BOOL)storeCredential:(AFOAuthCredential *)credential
+         withIdentifier:(NSString *)identifier
+      withAccessibility:(id)securityAccessibility;
+
+/**
+ Retrieves the OAuth credential stored with the specified service identifier from the Keychain.
+
+ @param identifier The service identifier associated with the specified credential.
+
+ @return The retrieved OAuth credential.
+ */
++ (AFOAuthCredential *)retrieveCredentialWithIdentifier:(NSString *)identifier;
+
+/**
+ Deletes the OAuth credential stored with the specified service identifier from the Keychain.
+
+ @param identifier The service identifier associated with the specified credential.
+
+ @return Whether or not the credential was deleted from the keychain.
+ */
++ (BOOL)deleteCredentialWithIdentifier:(NSString *)identifier;
+
+@end

--- a/AFOAuth2Manager/AFOAuthCredential.m
+++ b/AFOAuth2Manager/AFOAuthCredential.m
@@ -1,0 +1,197 @@
+// AFOAuthCredential.m
+//
+// Copyright (c) 2012-2015 AFNetworking (http://afnetworking.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Security/Security.h>
+
+#import "AFOAuthCredential.h"
+
+NSString * const kAFOAuth2CredentialServiceName = @"AFOAuthCredentialService";
+
+static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifier) {
+    NSCParameterAssert(identifier);
+
+    return @{
+             (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+             (__bridge id)kSecAttrService: kAFOAuth2CredentialServiceName,
+             (__bridge id)kSecAttrAccount: identifier
+             };
+}
+
+#pragma mark -
+
+@interface AFOAuthCredential ()
+@property (readwrite, nonatomic, copy) NSString *accessToken;
+@property (readwrite, nonatomic, copy) NSString *tokenType;
+@property (readwrite, nonatomic, copy) NSString *refreshToken;
+@property (readwrite, nonatomic, copy) NSDate *expiration;
+@end
+
+@implementation AFOAuthCredential
+@dynamic expired;
+
+#pragma mark -
+
++ (instancetype)credentialWithOAuthToken:(NSString *)token
+                               tokenType:(NSString *)type
+{
+    return [[self alloc] initWithOAuthToken:token tokenType:type];
+}
+
+- (id)initWithOAuthToken:(NSString *)token
+               tokenType:(NSString *)type
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.accessToken = token;
+    self.tokenType = type;
+
+    return self;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@ accessToken:\"%@\" tokenType:\"%@\" refreshToken:\"%@\" expiration:\"%@\">", [self class], self.accessToken, self.tokenType, self.refreshToken, self.expiration];
+}
+
+- (void)setRefreshToken:(NSString *)refreshToken
+{
+    _refreshToken = refreshToken;
+}
+
+- (void)setExpiration:(NSDate *)expiration
+{
+    _expiration = expiration;
+}
+
+- (void)setRefreshToken:(NSString *)refreshToken
+             expiration:(NSDate *)expiration
+{
+    NSParameterAssert(refreshToken);
+    NSParameterAssert(expiration);
+
+    self.refreshToken = refreshToken;
+    self.expiration = expiration;
+}
+
+- (BOOL)isExpired {
+    return [self.expiration compare:[NSDate date]] == NSOrderedAscending;
+}
+
+#pragma mark Keychain
+
++ (BOOL)storeCredential:(AFOAuthCredential *)credential
+         withIdentifier:(NSString *)identifier
+{
+    id securityAccessibility = nil;
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 43000) || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090)
+    if (&kSecAttrAccessibleWhenUnlocked != NULL) {
+        securityAccessibility = (__bridge id)kSecAttrAccessibleWhenUnlocked;
+    }
+#endif
+
+    return [[self class] storeCredential:credential withIdentifier:identifier withAccessibility:securityAccessibility];
+}
+
++ (BOOL)storeCredential:(AFOAuthCredential *)credential
+         withIdentifier:(NSString *)identifier
+      withAccessibility:(id)securityAccessibility
+{
+    NSMutableDictionary *queryDictionary = [AFKeychainQueryDictionaryWithIdentifier(identifier) mutableCopy];
+
+    if (!credential) {
+        return [self deleteCredentialWithIdentifier:identifier];
+    }
+
+    NSMutableDictionary *updateDictionary = [NSMutableDictionary dictionary];
+    updateDictionary[(__bridge id)kSecValueData] = [NSKeyedArchiver archivedDataWithRootObject:credential];
+
+    if (securityAccessibility) {
+        updateDictionary[(__bridge id)kSecAttrAccessible] = securityAccessibility;
+    }
+
+    OSStatus status;
+    BOOL exists = ([self retrieveCredentialWithIdentifier:identifier] != nil);
+
+    if (exists) {
+        status = SecItemUpdate((__bridge CFDictionaryRef)queryDictionary, (__bridge CFDictionaryRef)updateDictionary);
+    } else {
+        [queryDictionary addEntriesFromDictionary:updateDictionary];
+        status = SecItemAdd((__bridge CFDictionaryRef)queryDictionary, NULL);
+    }
+
+    if (status != errSecSuccess) {
+        NSLog(@"Unable to %@ credential with identifier \"%@\" (Error %li)", exists ? @"update" : @"add", identifier, (long int)status);
+    }
+
+    return (status == errSecSuccess);
+}
+
++ (BOOL)deleteCredentialWithIdentifier:(NSString *)identifier {
+    NSMutableDictionary *queryDictionary = [AFKeychainQueryDictionaryWithIdentifier(identifier) mutableCopy];
+
+    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)queryDictionary);
+
+    if (status != errSecSuccess) {
+        NSLog(@"Unable to delete credential with identifier \"%@\" (Error %li)", identifier, (long int)status);
+    }
+
+    return (status == errSecSuccess);
+}
+
++ (AFOAuthCredential *)retrieveCredentialWithIdentifier:(NSString *)identifier {
+    NSMutableDictionary *queryDictionary = [AFKeychainQueryDictionaryWithIdentifier(identifier) mutableCopy];
+    queryDictionary[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
+    queryDictionary[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
+
+    CFDataRef result = nil;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)queryDictionary, (CFTypeRef *)&result);
+
+    if (status != errSecSuccess) {
+        NSLog(@"Unable to fetch credential with identifier \"%@\" (Error %li)", identifier, (long int)status);
+        return nil;
+    }
+
+    return [NSKeyedUnarchiver unarchiveObjectWithData:(__bridge_transfer NSData *)result];
+}
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)decoder {
+    self = [super init];
+    self.accessToken = [decoder decodeObjectForKey:NSStringFromSelector(@selector(accessToken))];
+    self.tokenType = [decoder decodeObjectForKey:NSStringFromSelector(@selector(tokenType))];
+    self.refreshToken = [decoder decodeObjectForKey:NSStringFromSelector(@selector(refreshToken))];
+    self.expiration = [decoder decodeObjectForKey:NSStringFromSelector(@selector(expiration))];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)encoder {
+    [encoder encodeObject:self.accessToken forKey:NSStringFromSelector(@selector(accessToken))];
+    [encoder encodeObject:self.tokenType forKey:NSStringFromSelector(@selector(tokenType))];
+    [encoder encodeObject:self.refreshToken forKey:NSStringFromSelector(@selector(refreshToken))];
+    [encoder encodeObject:self.expiration forKey:NSStringFromSelector(@selector(expiration))];
+}
+
+@end

--- a/AFOAuth2Manager/AFOAuthCredential.m
+++ b/AFOAuth2Manager/AFOAuthCredential.m
@@ -105,9 +105,12 @@ static NSDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *identifi
 {
     id securityAccessibility = nil;
 #if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 43000) || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
     if (&kSecAttrAccessibleWhenUnlocked != NULL) {
         securityAccessibility = (__bridge id)kSecAttrAccessibleWhenUnlocked;
     }
+#pragma clang diagnostic pop
 #endif
 
     return [[self class] storeCredential:credential withIdentifier:identifier withAccessibility:securityAccessibility];


### PR DESCRIPTION
This adds a `AFHTTPSessionManager` subclass that fulfills the same role as the current `AFHTTPRequestOperationManager` based Manager. 

`AFOAuth2SessionManager`'s methods are analogous to `AFOAuth2RequestOperationManager`. The only difference being the return type.

The podspec is updated to include separate subpecs for the different Managers.

The `NSURLSession` subspec is compatible with AFNetworking 3.0, while still maintaining compatibility with AFNetworking 2.x.