### PR TITLE
Added the data task and response object as a callback argument for the

### DIFF
--- a/AFOAuth2Manager/AFOAuth2Manager.h
+++ b/AFOAuth2Manager/AFOAuth2Manager.h
@@ -100,67 +100,67 @@ NS_ASSUME_NONNULL_BEGIN
  @param username The username used for authentication
  @param password The password used for authentication
  @param scope The authorization scope
- @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
- @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes three arguments: the data task, the response object created by the client response serializer and the OAuth credential returned by the server.
+ @param failure A block object to be executed when the task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the data task and the error describing the network, parsing or OAuth error that occurred.
  */
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                                  username:(NSString *)username
                                                  password:(NSString *)password
                                                     scope:(nullable NSString *)scope
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure;
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 /**
  Creates and enqueues an `NSURLSessionTask` to authenticate against the server with a designated scope.
 
  @param URLString The URL string used to create the request URL.
  @param scope The authorization scope
- @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
- @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes three arguments: the data task, the response object created by the client response serializer and the OAuth credential returned by the server.
+ @param failure A block object to be executed when the task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the data task and the error describing the network, parsing or OAuth error that occurred.
  */
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                                     scope:(nullable NSString *)scope
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure;
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 /**
  Creates and enqueues an `NSURLSessionTask` to authenticate against the server using the specified refresh token.
  @param URLString The URL string used to create the request URL.
  @param refreshToken The OAuth refresh token
- @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
- @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes three arguments: the data task, the response object created by the client response serializer and the OAuth credential returned by the server.
+ @param failure A block object to be executed when the task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the data task and the error describing the network, parsing or OAuth error that occurred.
  */
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                              refreshToken:(NSString *)refreshToken
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure;
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 /**
  Creates and enqueues an `NSURLSessionTask` to authenticate against the server with an authorization code, redirecting to a specified URI upon successful authentication.
  @param URLString The URL string used to create the request URL.
  @param code The authorization code
  @param uri The URI to redirect to after successful authentication
- @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
- @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes three arguments: the data task, the response object created by the client response serializer and the OAuth credential returned by the server.
+ @param failure A block object to be executed when the task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the data task and the error describing the network, parsing or OAuth error that occurred.
  */
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                                      code:(NSString *)code
                                               redirectURI:(NSString *)uri
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure;
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 /**
  Creates and enqueues an `NSURLSessionTask` to authenticate against the server with the specified parameters.
 
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded and set in the request HTTP body.
- @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
- @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes three arguments: the data task, the response object created by the client response serializer and the OAuth credential returned by the server.
+ @param failure A block object to be executed when the task finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the data task and the error describing the network, parsing or OAuth error that occurred.
  */
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                                parameters:(NSDictionary *)parameters
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure;
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 @end
 

--- a/AFOAuth2Manager/AFOAuth2Manager.m
+++ b/AFOAuth2Manager/AFOAuth2Manager.m
@@ -143,8 +143,9 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
                                                  username:(NSString *)username
                                                  password:(NSString *)password
                                                     scope:(NSString *)scope
-                                                  success:(void (^)(AFOAuthCredential * _Nonnull))success
-                                                  failure:(void (^)(NSError * _Nonnull))failure {
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
+{
     NSParameterAssert(username);
     NSParameterAssert(password);
 
@@ -162,9 +163,9 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                                     scope:(NSString *)scope
-                                                  success:(void (^)(AFOAuthCredential * _Nonnull))success
-                                                  failure:(void (^)(NSError * _Nonnull))failure {
-
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
+{
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     [parameters setValue:kAFOAuthClientCredentialsGrantType forKey:@"grant_type"];
 
@@ -178,8 +179,8 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                              refreshToken:(NSString *)refreshToken
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     NSParameterAssert(refreshToken);
 
@@ -194,8 +195,8 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                                      code:(NSString *)code
                                               redirectURI:(NSString *)uri
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     NSParameterAssert(code);
     NSParameterAssert(uri);
@@ -211,8 +212,8 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
 
 - (NSURLSessionTask *)authenticateUsingOAuthWithURLString:(NSString *)URLString
                                                parameters:(NSDictionary *)parameters
-                                                  success:(void (^)(AFOAuthCredential *credential))success
-                                                  failure:(void (^)(NSError *error))failure
+                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject, AFOAuthCredential *credential))success
+                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     if (!self.useHTTPBasicAuthentication) {
@@ -225,14 +226,14 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
     task = [self POST:URLString parameters:parameters progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         if (!responseObject) {
             if (failure) {
-                failure(nil);
+                failure(task, nil);
             }
             return;
         }
 
         if ([responseObject valueForKey:@"error"]) {
             if (failure) {
-                failure(AFErrorFromRFC6749Section5_2Error(responseObject));
+                failure(task, AFErrorFromRFC6749Section5_2Error(responseObject));
             }
         }
 
@@ -260,12 +261,12 @@ static NSError * AFErrorFromRFC6749Section5_2Error(id object) {
         }
 
         if (success) {
-            success(credential);
+            success(task, responseObject, credential);
         }
 
     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
         if (failure) {
-            failure(error);
+            failure(task, error);
         }
     }];
 

--- a/Tests/AFOAuthManagerTests.m
+++ b/Tests/AFOAuthManagerTests.m
@@ -56,14 +56,16 @@
      username:@"demouser"
      password:@"testpass"
      scope:nil
-     success:^(AFOAuthCredential * _Nonnull credential) {
+     success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject, AFOAuthCredential * _Nonnull credential) {
+         XCTAssertNotNil(task);
+         XCTAssertNotNil(responseObject);
          XCTAssertNotNil(credential);
          XCTAssertNotNil(credential.accessToken);
          XCTAssertTrue([credential.tokenType isEqualToString:@"Bearer"]);
          XCTAssertNotNil(credential.refreshToken);
          [expectation fulfill];
      }
-     failure:^(NSError * _Nonnull error) {
+     failure:^(NSURLSessionDataTask * _Nonnull task, NSError * _Nonnull error) {
          XCTFail(@"Request should succeed");
      }];
 


### PR DESCRIPTION
success block and only the data task as a callback argument for the
failure block. Fixes the problem described in issue #84.
