### PR TITLE
Authorization header field is externed

### DIFF
--- a/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
+++ b/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.h
@@ -24,6 +24,8 @@
 
 @class AFOAuthCredential;
 
+extern NSString * const AFOAuth2HTTPRequestHeaderField;
+
 @interface AFHTTPRequestSerializer (OAuth2)
 
 /**

--- a/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.m
+++ b/AFOAuth2Manager/AFHTTPRequestSerializer+OAuth2.m
@@ -24,11 +24,13 @@
 #import "AFOAuth2Manager.h"
 #import "AFOAuthCredential.h"
 
+NSString * const AFOAuth2HTTPRequestHeaderField = @"Authorization";
+
 @implementation AFHTTPRequestSerializer (OAuth2)
 
 - (void)setAuthorizationHeaderFieldWithCredential:(AFOAuthCredential *)credential {
     if ([credential.tokenType compare:@"Bearer" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-        [self setValue:[NSString stringWithFormat:@"Bearer %@", credential.accessToken] forHTTPHeaderField:@"Authorization"];
+        [self setValue:[NSString stringWithFormat:@"Bearer %@", credential.accessToken] forHTTPHeaderField:AFOAuth2HTTPRequestHeaderField];
     }
 }
 


### PR DESCRIPTION
`setAuthorizationHeaderFieldWithCredential` in `AFHTTPRequestSerializer+OAuth2` was using hard-coded string:

``` objective-c
[self setValue:[NSString stringWithFormat:@"Bearer %@", credential.accessToken] 
forHTTPHeaderField:@"Authorization"];
```

String is declared as constant and extern'ed in header file:

``` objective-c
[self setValue:[NSString stringWithFormat:@"Bearer %@", credential.accessToken] 
forHTTPHeaderField:AFOAuth2HTTPRequestHeaderField];
```

Now you can check if your `requestSerializer` already has `Authorization` header field in it or not.
